### PR TITLE
update atuh

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,4 +22,24 @@ jobs:
 
       - name: Run API tests with service containers
         working-directory: api
-        run: bun run test
+        run: |
+          set -euo pipefail
+
+          test_status=0
+
+          cleanup() {
+            bun run test:db:down || true
+          }
+
+          trap cleanup EXIT
+
+          bun --env-file=.env.test run test:db:up
+          bun --env-file=.env.test run test:prisma:setup
+
+          for test_file in tests/*.test.ts; do
+            if ! bun --env-file=.env.test test --max-concurrency 1 "$test_file"; then
+              test_status=1
+            fi
+          done
+
+          exit "$test_status"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Harden CI test step to run test files serially with DB setup and teardown
- Replaces the single `bun run test` command in [test.yaml](.github/workflows/test.yaml) with a shell script that bootstraps the test DB and Prisma schema using `.env.test` before running tests.
- Runs each `tests/*.test.ts` file individually with `--max-concurrency 1`, aggregating failures so all files are attempted even if one fails.
- Always tears down the test DB on exit via a trapped `cleanup` function.
- Behavioral Change: CI step exit code now reflects aggregated per-file results rather than a single test run.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9f9c6a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->