### PR TITLE
fix: suppress React 19 ref warning in development

### DIFF
--- a/client/src/app/providers.tsx
+++ b/client/src/app/providers.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import "@/lib/suppress-react-ref-warning"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { useState } from "react"
 import queryClient from "@/config/queryClient"

--- a/client/src/lib/suppress-react-ref-warning.ts
+++ b/client/src/lib/suppress-react-ref-warning.ts
@@ -1,0 +1,27 @@
+const REACT_REF_WARNING = "Accessing element.ref was removed in React 19"
+
+type GlobalState = typeof globalThis & {
+    __feridinhaReactRefWarningSuppressed?: boolean
+}
+
+const globalState = globalThis as GlobalState
+
+if (
+    process.env.NODE_ENV === "development" &&
+    typeof window !== "undefined" &&
+    !globalState.__feridinhaReactRefWarningSuppressed
+) {
+    const originalConsoleError = console.error.bind(console)
+
+    console.error = (...args: Parameters<typeof console.error>) => {
+        const isReactRefWarning = args.some(
+            (arg) => typeof arg === "string" && arg.includes(REACT_REF_WARNING),
+        )
+
+        if (isReactRefWarning) return
+
+        originalConsoleError(...args)
+    }
+
+    globalState.__feridinhaReactRefWarningSuppressed = true
+}


### PR DESCRIPTION
## Summary

- suppress the known React 19 `element.ref` console warning in the browser during development
- preserve all other `console.error` output
- initialize the suppression once from the client providers module

## Testing

- Not run (not provided)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress React 19 `element.ref` deprecation warning in development
> Adds [suppress-react-ref-warning.ts](https://github.com/felipe-software/feridinha.com/pull/48/files#diff-23fe1f1d89a99f70308a619d38b5d145ce10a053582b2004e41ce6cc2bb6847e) which wraps `console.error` to filter out the `'Accessing element.ref was removed in React 19'` warning. The override runs once per runtime, only in browser development environments. It is initialized via a side-effect import in [providers.tsx](https://github.com/felipe-software/feridinha.com/pull/48/files#diff-95b47aa3d42d87b6ad4470dcc26e07c40a850adde63ff175b9d8d9a13bd475e9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c956eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->