### PR TITLE
Update prod

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,4 +22,25 @@ jobs:
 
       - name: Run API tests with service containers
         working-directory: api
-        run: bun run test
+        run: |
+          set -euo pipefail
+
+          test_status=0
+
+          cleanup() {
+            bun run test:db:down || true
+          }
+
+          trap cleanup EXIT
+
+          bun --env-file=.env.test run test:db:up
+          bun --env-file=.env.test run test:prisma:setup
+          mkdir -p /tmp/feridinha-dot-com/upload /tmp/feridinha-dot-com/preview
+
+          for test_file in tests/*.test.ts; do
+            if ! bun --env-file=.env.test test --max-concurrency 1 "$test_file"; then
+              test_status=1
+            fi
+          done
+
+          exit "$test_status"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,4 +22,24 @@ jobs:
 
       - name: Run API tests with service containers
         working-directory: api
-        run: bun run test
+        run: |
+          set -euo pipefail
+
+          test_status=0
+
+          cleanup() {
+            bun run test:db:down || true
+          }
+
+          trap cleanup EXIT
+
+          bun --env-file=.env.test run test:db:up
+          bun --env-file=.env.test run test:prisma:setup
+
+          for test_file in tests/*.test.ts; do
+            if ! bun --env-file=.env.test test --max-concurrency 1 "$test_file"; then
+              test_status=1
+            fi
+          done
+
+          exit "$test_status"

--- a/api/src/services/external-post/constants.ts
+++ b/api/src/services/external-post/constants.ts
@@ -3,14 +3,15 @@ import logger from "@/config/logger";
 
 export const externalPostRegexes = {
     reddit: /https?:\/\/(?:www\.)?(?:vx)?reddit\.com\/r\/[\w]+\/comments\/[\w]+/i,
-    instagram: /https?:\/\/(?:www\.)?(?:zz)?instagram\.com\/(?:reels?|p)\/[\w-]+/i,
+    instagram:
+        /https?:\/\/(?:www\.)?(?:zz|uu)?instagram\.com\/(?:(?:reels?|p)\/[\w-]+|stories\/[\w.]+\/\d+)(?:[/?#]|$)/i,
     tiktok: /https?:\/\/(?:www\.)?(?:ti|tn)ktok\.com\/@[\w.]+\/video\/\d+/i,
     twitter: /https?:\/\/(?:www\.)?(?:twitter|x)\.com\/\w+\/status\/\d+/i,
 } as const;
 
 const _PROXY_DOMAINS = {
     reddit: env.MURAL_VXREDDIT_URL,
-    instagram: "https://www.zzinstagram.com",
+    instagram: "https://www.uuinstagram.com",
     tiktok: "https://www.tnktok.com",
     twitter: "https://vxtwitter.com",
 } as const;
@@ -42,7 +43,7 @@ export const PROXY_HOSTS: Record<keyof typeof PROXY_DOMAINS, readonly string[]> 
         "redditmedia.com",
         "redditstatic.com",
     ],
-    instagram: ["zzinstagram.com"],
+    instagram: ["uuinstagram.com"],
     tiktok: ["tnktok.com"],
     twitter: ["vxtwitter.com"],
 };

--- a/api/src/services/external-post/parser.ts
+++ b/api/src/services/external-post/parser.ts
@@ -20,10 +20,17 @@ function getMeta($: cheerio.CheerioAPI, property: string | string[]): string | u
     return undefined;
 }
 
+function normalizeInstagramMediaUrl(url: string | undefined): string | undefined {
+    if (!url) return undefined;
+    return new URL(url, PROXY_DOMAINS.instagram).toString();
+}
+
 export function parseInstagramHtml(html: string) {
     const $ = cheerio.load(html);
-    const videoUrl = getMeta($, "og:video:secure_url") ?? getMeta($, "og:video") ?? getMeta($, "twitter:player:stream");
-    const imageUrl = getMeta($, "og:image");
+    const videoUrl = normalizeInstagramMediaUrl(
+        getMeta($, "og:video:secure_url") ?? getMeta($, "og:video") ?? getMeta($, "twitter:player:stream"),
+    );
+    const imageUrl = normalizeInstagramMediaUrl(getMeta($, "og:image"));
     const title = getMeta($, "og:title") ?? getMeta($, "twitter:title");
     const description = getMeta($, "og:description");
 

--- a/api/src/services/external-post/resolver.ts
+++ b/api/src/services/external-post/resolver.ts
@@ -25,7 +25,10 @@ export async function fetchHtml(
     fetcher: ExternalFetcher = safeFetchExternal,
 ): Promise<string> {
     const result = await fetcher(url, {
-        hostPolicy: { mode: "every-hop", hosts: PROXY_HOSTS[source] },
+        hostPolicy:
+            source === "instagram"
+                ? { mode: "initial-only", hosts: PROXY_HOSTS[source] }
+                : { mode: "every-hop", hosts: PROXY_HOSTS[source] },
         trustedPrivateHosts: source === "reddit" ? [new URL(PROXY_DOMAINS.reddit).hostname] : undefined,
         maxBytes: MAX_HTML_BYTES,
         headers: { "User-Agent": PROXY_USER_AGENTS[source] },

--- a/api/tests/externalPostParser.test.ts
+++ b/api/tests/externalPostParser.test.ts
@@ -15,6 +15,39 @@ describe("externalPostParser", () => {
             expect(result.title).toBe("@jumoproject");
             expect(result.description).toContain("Paris, c'est le génial");
         });
+
+        test("normaliza URL relativa de vídeo de Story usando o proxy do Instagram", () => {
+            const result = externalPostParser.parseInstagramHtml(`
+                <meta name="twitter:title" content="@vincentlerisson">
+                <meta property="og:video:secure_url" content="/videos/DbecORXjCE3/1">
+                <meta property="og:image" content="/images/DbecORXjCE3/1.jpg">
+            `);
+
+            expect(result).toMatchObject({
+                contentUrl: "https://www.uuinstagram.com/videos/DbecORXjCE3/1",
+                contentType: "VIDEO",
+                title: "@vincentlerisson",
+            });
+        });
+
+        test("normaliza URL relativa de imagem de Story usando o proxy do Instagram", () => {
+            const result = externalPostParser.parseInstagramHtml(
+                '<meta property="og:image" content="/images/story-image.webp">',
+            );
+
+            expect(result).toEqual({
+                contentUrl: "https://www.uuinstagram.com/images/story-image.webp",
+                contentType: "IMAGE",
+            });
+        });
+
+        test("preserva URL absoluta de mídia", () => {
+            const result = externalPostParser.parseInstagramHtml(
+                '<meta property="og:video" content="https://cdn.example.com/video.mp4">',
+            );
+
+            expect(result.contentUrl).toBe("https://cdn.example.com/video.mp4");
+        });
     });
 
     describe("parseTiktokHtml", () => {

--- a/api/tests/externalPostResolver.test.ts
+++ b/api/tests/externalPostResolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { PROXY_HOSTS } from "@/services/external-post/constants";
 import { externalPostResolver, fetchHtml, toProxyUrl } from "@/services/external-post/resolver";
 
 const TEST_URLS = {
@@ -6,6 +7,8 @@ const TEST_URLS = {
     instagram: "https://www.instagram.com/reels/DU04xhLCKEr/",
     tiktok: "https://www.tiktok.com/@carlo99992/video/7607681087707417876",
 };
+
+const INSTAGRAM_STORY_URL = "https://www.instagram.com/stories/vincentlerisson/3953721648901529911/";
 
 function looksLikeHtml(str: string): boolean {
     return str.length > 0 && (str.includes("<html") || str.includes("<!DOCTYPE") || str.includes("<HTML"));
@@ -73,6 +76,23 @@ describe("externalPostResolver platform detection", () => {
         expect(externalPostResolver.detectPlatform(url)).toBe(platform);
     });
 
+    test.each([
+        INSTAGRAM_STORY_URL,
+        "https://instagram.com/stories/user_name/3953721648901529911/",
+        "https://instagram.com/stories/user.name/3953721648901529911/?utm_source=test",
+    ])("detecta Story específico do Instagram: %s", (url) => {
+        expect(externalPostResolver.detectPlatform(url)).toBe("instagram");
+    });
+
+    test.each([
+        "https://instagram.com/stories/user.name/",
+        "https://instagram.com/stories/user.name/not-numeric/",
+        "https://instagram.com/stories/user-name/3953721648901529911/",
+        "https://instagram.com.evil.test/stories/user/3953721648901529911/",
+    ])("rejeita Story inválido ou origem semelhante: %s", (url) => {
+        expect(externalPostResolver.detectPlatform(url)).toBeNull();
+    });
+
     test("rejects unsupported origins before fetching", async () => {
         await expect(externalPostResolver.resolveHtml("https://example.com/post/1")).rejects.toThrow(
             "Unsupported external post URL",
@@ -87,6 +107,21 @@ describe("externalPostResolver platform detection", () => {
         expect(toProxyUrl("not a url", "reddit")).toBe("not a url");
     });
 
+    test.each([
+        "https://www.instagram.com/p/ABC123/?utm_source=test#media",
+        "https://www.instagram.com/reel/ABC123/?utm_source=test#media",
+        "https://www.instagram.com/reels/ABC123/?utm_source=test#media",
+        `${INSTAGRAM_STORY_URL}?utm_source=test#media`,
+    ])("converte todo link do Instagram para uuinstagram: %s", (url) => {
+        const original = new URL(url);
+        const result = new URL(toProxyUrl(url, "instagram"));
+
+        expect(result.hostname).toBe("www.uuinstagram.com");
+        expect(result.pathname).toBe(original.pathname);
+        expect(result.search).toBe(original.search);
+        expect(result.hash).toBe(original.hash);
+    });
+
     test("fetchHtml aplica headers/limite da plataforma e decodifica UTF-8", async () => {
         const fakeFetch = async (_url: string, options: { maxBytes: number; headers?: Record<string, string> }) => {
             expect(options.maxBytes).toBe(5 * 1024 * 1024);
@@ -98,6 +133,29 @@ describe("externalPostResolver platform detection", () => {
             };
         };
         expect(await fetchHtml("https://vxreddit.com/post", "reddit", fakeFetch as never)).toBe("olá");
+    });
+
+    test.each([
+        ["instagram", "initial-only"],
+        ["reddit", "every-hop"],
+        ["tiktok", "every-hop"],
+        ["twitter", "every-hop"],
+    ] as const)("fetchHtml usa política correta para %s", async (source, mode) => {
+        const fakeFetch = async (
+            _url: string,
+            options: { hostPolicy: { mode: string; hosts: readonly string[] } },
+        ) => {
+            expect(options.hostPolicy).toEqual({ mode, hosts: PROXY_HOSTS[source] });
+            return {
+                body: Buffer.from("<html></html>"),
+                contentType: "text/html",
+                finalUrl: new URL(`https://${PROXY_HOSTS[source][0]}`),
+            };
+        };
+
+        await expect(fetchHtml(`https://${PROXY_HOSTS[source][0]}/post`, source, fakeFetch as never)).resolves.toBe(
+            "<html></html>",
+        );
     });
 
     test.each(Object.entries(TEST_URLS) as Array<[keyof typeof TEST_URLS, string]>)(

--- a/client/src/app/providers.tsx
+++ b/client/src/app/providers.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import "@/lib/suppress-react-ref-warning"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { useState } from "react"
 import queryClient from "@/config/queryClient"

--- a/client/src/lib/suppress-react-ref-warning.ts
+++ b/client/src/lib/suppress-react-ref-warning.ts
@@ -1,0 +1,27 @@
+const REACT_REF_WARNING = "Accessing element.ref was removed in React 19"
+
+type GlobalState = typeof globalThis & {
+    __feridinhaReactRefWarningSuppressed?: boolean
+}
+
+const globalState = globalThis as GlobalState
+
+if (
+    process.env.NODE_ENV === "development" &&
+    typeof window !== "undefined" &&
+    !globalState.__feridinhaReactRefWarningSuppressed
+) {
+    const originalConsoleError = console.error.bind(console)
+
+    console.error = (...args: Parameters<typeof console.error>) => {
+        const isReactRefWarning = args.some(
+            (arg) => typeof arg === "string" && arg.includes(REACT_REF_WARNING),
+        )
+
+        if (isReactRefWarning) return
+
+        originalConsoleError(...args)
+    }
+
+    globalState.__feridinhaReactRefWarningSuppressed = true
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Switch Instagram proxy from zzinstagram.com to uuinstagram.com and add Story URL support
- Updates the Instagram proxy domain from `zzinstagram.com` to `uuinstagram.com` in [constants.ts](https://github.com/felipe-software/feridinha.com/pull/52/files#diff-3aa476607312f6b29202b9df997095e132abc4259c0b2960c196c7b2a72c6d7a), including regex patterns and the host allowlist.
- Adds regex support for Instagram Story URLs (`stories/<username>/<numeric_id>`) in the URL detector.
- Introduces `normalizeInstagramMediaUrl` in [parser.ts](https://github.com/felipe-software/feridinha.com/pull/52/files#diff-7c12c5aacfce2a4199b0c62e52476e637d7a5cb5f8a3f993f6a26fb8b6947fbf) to resolve relative media URLs from Instagram HTML to absolute URLs under the proxy domain.
- Changes `fetchHtml` in [resolver.ts](https://github.com/felipe-software/feridinha.com/pull/52/files#diff-9244764453856d8b2e684453bc57567f7a9b8699c0b7ce3608a368b32e8ff93b) to use `initial-only` host policy for Instagram requests instead of `every-hop`.
- Adds a dev-only console.error patch in [suppress-react-ref-warning.ts](https://github.com/felipe-software/feridinha.com/pull/52/files#diff-23fe1f1d89a99f70308a619d38b5d145ce10a053582b2004e41ce6cc2bb6847e) to silence the React 19 ref deprecation warning in the browser.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33a7661.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->