### PR TITLE
fix: check upload names against database

### DIFF
--- a/api/src/utils/upload.ts
+++ b/api/src/utils/upload.ts
@@ -1,5 +1,6 @@
 import logger from "@/config/logger";
 import constants from "@/constants";
+import database from "@/services/database";
 import fileUtils from "@/utils/file";
 import { tryP } from "@/utils/promises";
 import { DefaultExiftoolArgs, DefaultExifToolOptions, ExifTool } from "exiftool-vendored";
@@ -57,13 +58,17 @@ const generateUploadName = async (originalName: string): Promise<UploadNameResul
     }
     result += extension;
 
-    const fileWithPath = fileUtils.getUploadFilePath(result);
-    const doesFileAlreadyExists = await fileUtils.checkIfFileExists(fileWithPath);
-    if (doesFileAlreadyExists) {
+    const existingUpload = await database.upload.findUnique({
+        where: { name: result },
+        select: { name: true },
+    });
+    if (existingUpload) {
         logger.warn({ filename: result, iteration }, "Arquivo já existe");
         iteration += 1;
         return generateUploadName(originalName);
     }
+
+    const fileWithPath = fileUtils.getUploadFilePath(result);
     return { filename: result, filenameWithPath: fileWithPath };
 };
 

--- a/api/tests/utils.test.ts
+++ b/api/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import cryptography from "@/config/cryptography";
 import { cacheService } from "@/services/cache";
+import database from "@/services/database";
 import fileUtils from "@/utils/file";
 import { ExternalServiceError, getUpstreamStatus, publicErrorDetails } from "@/utils/httpErrors";
 import { readCookie } from "@/utils/cookies";
@@ -92,21 +93,48 @@ describe("validação e nomes de upload", () => {
     });
 
     test("gera nomes com extensão e comprimentos esperados", async () => {
-        const upload = await uploadUtils.generateUploadName("photo.png");
-        expect(upload.filename).toMatch(/^[A-Za-z0-9]{5}\.png$/);
-        expect(upload.filenameWithPath).toEndWith(upload.filename);
-        expect(await uploadUtils.generateAlbumName()).toMatch(/^[A-Za-z0-9]{12}$/);
+        const originalFindUnique = database.upload.findUnique;
+        let calls = 0;
+        database.upload.findUnique = (async () => {
+            calls += 1;
+            return null;
+        }) as never;
+        try {
+            const upload = await uploadUtils.generateUploadName("photo.png");
+            expect(upload.filename).toMatch(/^[A-Za-z0-9]{5}\.png$/);
+            expect(upload.filenameWithPath).toEndWith(upload.filename);
+            expect(calls).toBe(1);
+            expect(await uploadUtils.generateAlbumName()).toMatch(/^[A-Za-z0-9]{12}$/);
+        } finally {
+            database.upload.findUnique = originalFindUnique;
+        }
     });
 
     test("tenta novamente quando há colisão de nome", async () => {
-        const originalCheck = fileUtils.checkIfFileExists;
+        const originalFindUnique = database.upload.findUnique;
         let calls = 0;
-        fileUtils.checkIfFileExists = async () => ++calls === 1;
+        database.upload.findUnique = (async ({ where }: { where: { name: string } }) => {
+            calls += 1;
+            return calls === 1 ? { name: where.name } : null;
+        }) as never;
         try {
             expect((await uploadUtils.generateUploadName("photo.jpg")).filename).toEndWith(".jpg");
             expect(calls).toBe(2);
         } finally {
-            fileUtils.checkIfFileExists = originalCheck;
+            database.upload.findUnique = originalFindUnique;
+        }
+    });
+
+    test("propaga falha ao consultar colisões no banco", async () => {
+        const originalFindUnique = database.upload.findUnique;
+        const databaseError = new Error("database unavailable");
+        database.upload.findUnique = (async () => {
+            throw databaseError;
+        }) as never;
+        try {
+            await expect(uploadUtils.generateUploadName("photo.png")).rejects.toBe(databaseError);
+        } finally {
+            database.upload.findUnique = originalFindUnique;
         }
     });
 


### PR DESCRIPTION
## Summary
- check generated upload names against PostgreSQL instead of the local upload directory
- retry name generation when Upload.name already exists, including soft-deleted records
- preserve the existing five-character filename format and local filesystem helper
- propagate database lookup failures instead of uploading an unchecked key

## Validation
- bunx tsc --noEmit
- API test suite: 319 passed, 6 skipped, 0 failed

## Limitation
This prevents collisions with names registered in PostgreSQL. Orphaned S3 objects and the small check-then-write concurrency window remain outside this change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `generateUploadName` to check name collisions against the database
> Replaces the filesystem existence check in `generateUploadName` ([upload.ts](https://github.com/felipe-software/feridinha.com/pull/58/files#diff-f1bebe19e29e1158ff0d36ff8a3b8fcbfe9cacf003b0378e597fce6eb52ef8d9)) with a database lookup via `database.upload.findUnique`. On a collision, the function logs a warning, increments the iteration counter, and retries recursively. Tests in [utils.test.ts](https://github.com/felipe-software/feridinha.com/pull/58/files#diff-36ea898bd9fa26acf480c58f556565120ac480c01cbc1e17868d711b8cd124de) are updated to stub the database call and a new test covers error propagation when the lookup throws.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7e6a96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->