### PR TITLE
feat(analytics): track GitHub badge clicks in PostHog

### DIFF
--- a/client/src/components/Navbar/index.tsx
+++ b/client/src/components/Navbar/index.tsx
@@ -156,7 +156,7 @@ function NavBar_({
                 </LogoText>
             </Link>
             <div className="description-container">
-                <OpenSourceBadge isOpenSource={isOpenSource} />
+                <OpenSourceBadge isOpenSource={isOpenSource} username={user.data?.name} />
                 {!isOpenSource && (
                     <Tooltip content={t("brainMade")} arrow={false} maxWidth={400}>
                         <BrainMadeWrapper

--- a/client/src/components/OpenSourceBadge/index.tsx
+++ b/client/src/components/OpenSourceBadge/index.tsx
@@ -4,12 +4,20 @@ import { GITHUB_REPOSITORY_URL } from "@/lib/links"
 import { Container, Content, Spotlight } from "@/components/OpenSourceBadge/styles"
 import { animate, useMotionTemplate, useMotionValue, useReducedMotion } from "motion/react"
 import { useTranslations } from "next-intl"
+import { usePostHog } from "posthog-js/react"
 import { useRef } from "react"
 import type { FocusEventHandler, PointerEventHandler } from "react"
 import { FaGithub } from "react-icons/fa6"
 
-export const OpenSourceBadge = ({ isOpenSource }: { isOpenSource: boolean }) => {
+export const OpenSourceBadge = ({
+    isOpenSource,
+    username,
+}: {
+    isOpenSource: boolean
+    username?: string
+}) => {
     const t = useTranslations("Nav")
+    const posthog = usePostHog()
     const spotlightX = useMotionValue(0)
     const spotlightY = useMotionValue(0)
     const spotlightRadius = useMotionValue(0)
@@ -83,6 +91,12 @@ export const OpenSourceBadge = ({ isOpenSource }: { isOpenSource: boolean }) => 
             onPointerLeave={closeSpotlight}
             onFocus={handleFocus}
             onBlur={closeSpotlight}
+            onClick={() => {
+                posthog.capture("open_source_clicked", {
+                    url: GITHUB_REPOSITORY_URL,
+                    ...(username ? { username } : {}),
+                })
+            }}
         >
             <Content>
                 <FaGithub />


### PR DESCRIPTION
## Summary

- Track open-source GitHub badge clicks with the `open_source_clicked` PostHog event.
- Include the repository URL and authenticated username when available.
- Pass the current username from the navbar to the badge component.

## Testing

- Not run (not provided).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track GitHub badge clicks in PostHog via `OpenSourceBadge`
> Adds a PostHog `open_source_clicked` event to the `OpenSourceBadge` component, fired when a user clicks the badge anchor. The event includes the repository URL and, when available, the username passed down from `Navbar`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2ef2881. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->