### PR TITLE
fix(analytics): preserve PostHog ingestion trailing slashes

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -5,6 +5,9 @@ import { SEO_REDIRECTS } from "./src/config/seoRedirects"
 
 const nextConfig: NextConfig = {
     reactStrictMode: true,
+    // PostHog ingestion paths include a trailing slash. Avoid redirecting replay
+    // payloads before the reverse proxy forwards them upstream.
+    skipTrailingSlashRedirect: true,
     typescript: {
         ignoreBuildErrors: true,
     },

--- a/client/tests/posthog.test.ts
+++ b/client/tests/posthog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import nextConfig from "../next.config"
 import {
     POSTHOG_ASSET_PROXY_PATH,
     obfuscatePostHogAssetUrl,
@@ -21,5 +22,11 @@ describe("PostHog asset aliases", () => {
         expect(new URL(alias).pathname).toStartWith(`${POSTHOG_ASSET_PROXY_PATH}/`)
         expect(alias).not.toContain(path.split("/").at(-1)!.split("?")[0])
         expect(decodeAlias(alias)).toBe(path)
+    })
+})
+
+describe("PostHog ingestion proxy", () => {
+    test("preserves trailing slashes used by ingestion endpoints", () => {
+        expect(nextConfig.skipTrailingSlashRedirect).toBe(true)
     })
 })


### PR DESCRIPTION
## Summary

- Disable Next.js trailing-slash redirects so PostHog replay ingestion payloads reach the reverse proxy unchanged.
- Add a regression test covering the Next.js configuration.

## Testing

- Not run (change request content generated from the provided diff).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `skipTrailingSlashRedirect: true` in Next.js config to preserve PostHog ingestion paths
> Next.js by default redirects requests to add or remove trailing slashes, which breaks PostHog ingestion endpoints that require exact path matching. Setting `skipTrailingSlashRedirect: true` in [next.config.ts](https://github.com/felipe-software/feridinha.com/pull/62/files#diff-bb35b6fdef8ccbdb298704909e9b797f5a5112ff6afb9be72c7110001dec9fb6) disables this behavior. A test in [posthog.test.ts](https://github.com/felipe-software/feridinha.com/pull/62/files#diff-bf052395a8f37a30e165b3ba35d7bba0334af1e9c591945925757f69e49d99fd) asserts the flag remains enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c49b5f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->