### PR TITLE
fix(navbar): hide open source badge on smaller screens

### DIFF
--- a/client/src/components/OpenSourceBadge/styles.ts
+++ b/client/src/components/OpenSourceBadge/styles.ts
@@ -28,6 +28,10 @@ export const Container = styled.a`
     @media (prefers-reduced-motion: reduce) {
         transition: none;
     }
+
+    @media (max-width: 68.75rem) {
+        display: none;
+    }
 `
 
 export const Content = styled.span`


### PR DESCRIPTION
## Summary

- Hide the open source navbar badge on viewports up to `68.75rem`.
- Prevent the badge from crowding navigation content on smaller screens.

## Testing

- Not run (responsive CSS-only change).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide open source badge on viewports narrower than 68.75rem
> Adds a `max-width: 68.75rem` media query to the `OpenSourceBadge` `Container` styled-component in [styles.ts](https://github.com/felipe-software/feridinha.com/pull/64/files#diff-4ba89ceed71c3644282f81cd7610a80952ccdaf1b4f9a02a0611a6fe0f3273cc) that sets `display: none`, preventing the badge from rendering on smaller screens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17ad6bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->