### PR TITLE
update

### DIFF
--- a/client/src/components/OpenSourceBadge/styles.ts
+++ b/client/src/components/OpenSourceBadge/styles.ts
@@ -28,6 +28,10 @@ export const Container = styled.a`
     @media (prefers-reduced-motion: reduce) {
         transition: none;
     }
+
+    @media (max-width: 68.75rem) {
+        display: none;
+    }
 `
 
 export const Content = styled.span`


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Hide `OpenSourceBadge` on viewports narrower than 68.75rem
Adds a `max-width: 68.75rem` media query to the `Container` styled-component in [styles.ts](https://github.com/felipe-software/feridinha.com/pull/65/files#diff-4ba89ceed71c3644282f81cd7610a80952ccdaf1b4f9a02a0611a6fe0f3273cc) that sets `display: none`, hiding the badge on smaller screens.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba70e05.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->