### PR TITLE
fix: aumenta rate limits de auth

### DIFF
--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -14,7 +14,7 @@ const forcedRateLimit = env.NODE_ENV === "test" ? 99999999 : null
 const rateLimit = {
     login: expressRateLimit({
         windowMs: 1 * 60 * 1000,
-        max: forcedRateLimit ?? 20,
+        max: forcedRateLimit ?? 40,
         ...headers,
         message: rateLimitMessage,
     }),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Increase auth login rate limit from 20 to 40 requests per minute
Doubles the max allowed requests in the `rateLimit.login` middleware in [rate-limit.ts](https://github.com/felipe-software/feridinha.com/pull/70/files#diff-b5e0588a654542ed43db15c7e4385dcab82dcebcddf7310271157200ff1fce2d) when no `forcedRateLimit` is configured.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized cefada8.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->