### PR TITLE
fix: evita refetch de queries ao refocar a janela

### DIFF
--- a/client/src/config/queryClient.ts
+++ b/client/src/config/queryClient.ts
@@ -2,12 +2,10 @@ import { QueryClient } from "@tanstack/react-query";
 
 const queryClient = new QueryClient({
     defaultOptions: {
-        // queries: {
-        //     refetchOnMount: false,
-        //     refetchOnWindowFocus: false,
-        //     refetchOnReconnect: false,
-        //     refetchInterval: false,
-        // },
+        queries: {
+            refetchOnWindowFocus: false,
+            staleTime: Infinity,
+        },
     },
 })
 


### PR DESCRIPTION
- Mantém os dados em cache sem expiração automática

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable refetch on window focus and set infinite stale time in QueryClient
> Sets `refetchOnWindowFocus: false` and `staleTime: Infinity` as default query options in [queryClient.ts](https://github.com/felipe-software/feridinha.com/pull/72/files#diff-599e4be1a647c604229a8b9ca7ef71192bf2a6e8ab1d5bbe0d2b2c2b33d85632). This prevents all queries from automatically re-fetching when the browser window regains focus. Behavioral Change: queries that previously refreshed on window focus will now only fetch when explicitly triggered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a31557.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->