### PR TITLE
fix: increase upload proxy timeout

### DIFF
--- a/api/src/services/static.ts
+++ b/api/src/services/static.ts
@@ -19,7 +19,7 @@ const safePreviewMediaTypes = ["mp4", "mkv", "webm", "avif"];
 export const waitForCacheRelease = async (
     rawName: string,
     context: { contentType: string | false; isChatterinoResolver: boolean },
-    timeoutMs = 4000,
+    timeoutMs = 30_000,
     pollMs = 50,
 ) => {
     let totalTime = 0;


### PR DESCRIPTION
## Summary

- increase the `f.feridinha.com` cache-release wait from 4 seconds to 30 seconds
- give large video uploads more time to reach `c.feridinha.com` before redirecting

## Validation

- `./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`
- `bun test tests/services.test.ts` could not run because the local test database is missing the `public.User` table

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `waitForCacheRelease` default timeout from 4s to 30s
> The default `timeoutMs` in `waitForCacheRelease` in [static.ts](https://github.com/felipe-software/feridinha.com/pull/73/files#diff-89d40f0e4216d955e958f0ff30ca9a8747c56ab8639c829b387bc8086e053779) was 4,000 ms, causing upload proxy requests to time out too quickly. Increasing it to 30,000 ms reduces premature timeout log events during slow uploads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1564ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->