### PR TITLE
fix: extend upload proxy timeout

### DIFF
--- a/api/src/services/static.ts
+++ b/api/src/services/static.ts
@@ -19,7 +19,7 @@ const safePreviewMediaTypes = ["mp4", "mkv", "webm", "avif"];
 export const waitForCacheRelease = async (
     rawName: string,
     context: { contentType: string | false; isChatterinoResolver: boolean },
-    timeoutMs = 4000,
+    timeoutMs = 30_000,
     pollMs = 50,
 ) => {
     let totalTime = 0;


### PR DESCRIPTION
Merge pull request #61 from felipe-software/prod

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend `waitForCacheRelease` upload proxy timeout from 4s to 30s
> Increases the default `timeoutMs` value in `waitForCacheRelease` in [static.ts](https://github.com/felipe-software/feridinha.com/pull/74/files#diff-89d40f0e4216d955e958f0ff30ca9a8747c56ab8639c829b387bc8086e053779) from 4,000 ms to 30,000 ms. This prevents premature timeout logs and early resolution during slow uploads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76e1a18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->