### PR TITLE
feat(analytics): track Twitch auth events separately

### DIFF
--- a/api/src/controllers/login.ts
+++ b/api/src/controllers/login.ts
@@ -3,6 +3,7 @@ import achievements, { achievementsOrder } from "@/handlers/achievements";
 import session from "@/handlers/session";
 import { AUTHENTICATED_USER_INCLUDE } from "@/models/userModel";
 import database from "@/services/database";
+import posthog from "@/services/posthog";
 import { findOrCreateOAuthUser } from "@/services/oauth/accounts";
 import { mergeOAuthUsers, OAuthMergeError } from "@/services/oauth/merge";
 import {
@@ -194,9 +195,12 @@ const oauthCallback: RequestHandler = async (req, res) => {
             return res.redirect(clientRedirect("/dashboard", "oauth-link", completionTicket));
         }
 
-        const oauthUser = await findOrCreateOAuthUser(provider.adapter.provider, profile);
+        const { user: oauthUser, created } = await findOrCreateOAuthUser(provider.adapter.provider, profile);
         const appSession = await createApplicationSession(oauthUser.id);
         req.session = { user: appSession.user };
+        posthog.capture(appSession.user.id, created ? "account_created" : "login", {
+            auth_provider: provider.slug,
+        });
         res.cookie("Token", appSession.token, {
             httpOnly: false,
             sameSite: "lax",

--- a/api/src/services/oauth/accounts.ts
+++ b/api/src/services/oauth/accounts.ts
@@ -46,10 +46,10 @@ const recoverConcurrentAccount = async (provider: OAuthProvider, profile: OAuthP
 
 export const findOrCreateOAuthUser = async (provider: OAuthProvider, profile: OAuthProfile) => {
     const existing = await findAccountUser(provider, profile.providerAccountId);
-    if (existing) return touchAccount(provider, profile);
+    if (existing) return { user: await touchAccount(provider, profile), created: false };
 
     try {
-        return await database.user.create({
+        const user = await database.user.create({
             data: {
                 name: profile.displayName,
                 profileImage: profile.profileImage,
@@ -66,7 +66,8 @@ export const findOrCreateOAuthUser = async (provider: OAuthProvider, profile: OA
                 },
             },
         });
+        return { user, created: true };
     } catch (error) {
-        return recoverConcurrentAccount(provider, profile, error);
+        return { user: await recoverConcurrentAccount(provider, profile, error), created: false };
     }
 };

--- a/api/tests/login.test.ts
+++ b/api/tests/login.test.ts
@@ -10,8 +10,9 @@ import twitch from "@/services/twitch";
 import { createOAuthState, oauthStatesMatch } from "@/controllers/login";
 import { ExternalServiceError } from "@/utils/httpErrors";
 import achievements from "@/handlers/achievements";
-import { getOAuthProvider, type OAuthProviderSlug } from "@/services/oauth";
+import { getOAuthProvider, providerFromSlug, type OAuthProviderSlug } from "@/services/oauth";
 import { mergeConfirmationStore } from "@/services/oauth/state";
+import posthog from "@/services/posthog";
 
 let testUser: TestUser;
 const oauthUserIds: string[] = [];
@@ -382,43 +383,54 @@ describe("Login Routes", () => {
             });
         };
 
-        test.each(["google", "discord"] as const)("cria e reutiliza usuário com %s", async (provider) => {
-            const providerAccountId = `${provider}-${crypto.randomUUID()}`;
-            const restore = mockProvider(provider, providerAccountId);
-            try {
-                const first = await finishProviderCallback(provider);
-                expect(first.status).toBe(302);
-                expect(first.headers.get("set-cookie")).toContain("Token=");
+        test.each(["twitch", "google", "discord"] as const)(
+            "cria e reutiliza usuário com %s e registra os eventos de autenticação",
+            async (provider) => {
+                const providerAccountId = `${provider}-${crypto.randomUUID()}`;
+                const restore = mockProvider(provider, providerAccountId);
+                const capturedEvents: Parameters<typeof posthog.capture>[] = [];
+                const originalCapture = posthog.capture;
+                posthog.capture = (...args) => capturedEvents.push(args);
+                try {
+                    const first = await finishProviderCallback(provider);
+                    expect(first.status).toBe(302);
+                    expect(first.headers.get("set-cookie")).toContain("Token=");
 
-                const account = await database.oAuthAccount.findUniqueOrThrow({
-                    where: {
-                        provider_providerAccountId: {
-                            provider: provider.toUpperCase() as "GOOGLE" | "DISCORD",
-                            providerAccountId,
-                        },
-                    },
-                    include: { user: true },
-                });
-                oauthUserIds.push(account.userId);
-                expect(account.user.name).toBe(`${provider} user`);
-
-                const second = await finishProviderCallback(provider);
-                expect(second.status).toBe(302);
-                const users = await database.user.count({
-                    where: {
-                        oauthAccounts: {
-                            some: {
-                                provider: provider.toUpperCase() as "GOOGLE" | "DISCORD",
+                    const account = await database.oAuthAccount.findUniqueOrThrow({
+                        where: {
+                            provider_providerAccountId: {
+                                provider: providerFromSlug(provider),
                                 providerAccountId,
                             },
                         },
-                    },
-                });
-                expect(users).toBe(1);
-            } finally {
-                restore();
-            }
-        });
+                        include: { user: true },
+                    });
+                    oauthUserIds.push(account.userId);
+                    expect(account.user.name).toBe(`${provider} user`);
+
+                    const second = await finishProviderCallback(provider);
+                    expect(second.status).toBe(302);
+                    const users = await database.user.count({
+                        where: {
+                            oauthAccounts: {
+                                some: {
+                                    provider: providerFromSlug(provider),
+                                    providerAccountId,
+                                },
+                            },
+                        },
+                    });
+                    expect(users).toBe(1);
+                    expect(capturedEvents).toEqual([
+                        [account.userId, "account_created", { auth_provider: provider }],
+                        [account.userId, "login", { auth_provider: provider }],
+                    ]);
+                } finally {
+                    restore();
+                    posthog.capture = originalCapture;
+                }
+            },
+        );
 
         test("callback concorrente reutiliza a identidade sem criar usuário órfão", async () => {
             const providerAccountId = `google-concurrent-${crypto.randomUUID()}`;


### PR DESCRIPTION
- Capture account creation and returning login events
- Tag both events with the Twitch auth provider

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track Twitch auth events separately in PostHog on OAuth callback
> - Updates `findOrCreateOAuthUser` in [accounts.ts](https://github.com/felipe-software/feridinha.com/pull/77/files#diff-61b8c95d45779d4f737071020e5763504e5f7c576251def38281c0831298c0bf) to return `{ user, created }` instead of a bare user, so callers can distinguish new registrations from existing logins.
> - The `oauthCallback` handler in [login.ts](https://github.com/felipe-software/feridinha.com/pull/77/files#diff-713ee22159fef3956727a60fa05e87c1feb5f77104b425d4373b2a740aa3e8fc) now calls `posthog.capture` after session creation, emitting `account_created` or `login` with `{ auth_provider: <provider slug> }`.
> - Expands OAuth flow tests to cover the `twitch` provider and asserts both events are emitted in the correct order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be174fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->