### PR TITLE
feat: setup signup and login stats

### DIFF
--- a/api/src/controllers/login.ts
+++ b/api/src/controllers/login.ts
@@ -29,6 +29,7 @@ import { Prisma } from "@prisma/client";
 import crypto from "crypto";
 import type { Request, RequestHandler, Response } from "express";
 import constants from "@/constants";
+import posthog from "@/services/posthog";
 
 export { createOAuthState, oauthStatesMatch };
 
@@ -194,9 +195,17 @@ const oauthCallback: RequestHandler = async (req, res) => {
             return res.redirect(clientRedirect("/dashboard", "oauth-link", completionTicket));
         }
 
-        const oauthUser = await findOrCreateOAuthUser(provider.adapter.provider, profile);
+        const { user: oauthUser, isNewUser } = await findOrCreateOAuthUser(
+            provider.adapter.provider,
+            profile,
+        );
         const appSession = await createApplicationSession(oauthUser.id);
         req.session = { user: appSession.user };
+        posthog.capture(
+            oauthUser.id,
+            isNewUser ? "user_signed_up" : "user_logged_in",
+            { oauth_provider: provider.slug },
+        );
         res.cookie("Token", appSession.token, {
             httpOnly: false,
             sameSite: "lax",

--- a/api/src/services/oauth/accounts.ts
+++ b/api/src/services/oauth/accounts.ts
@@ -46,10 +46,15 @@ const recoverConcurrentAccount = async (provider: OAuthProvider, profile: OAuthP
 
 export const findOrCreateOAuthUser = async (provider: OAuthProvider, profile: OAuthProfile) => {
     const existing = await findAccountUser(provider, profile.providerAccountId);
-    if (existing) return touchAccount(provider, profile);
+    if (existing) {
+        return {
+            user: await touchAccount(provider, profile),
+            isNewUser: false,
+        };
+    }
 
     try {
-        return await database.user.create({
+        const user = await database.user.create({
             data: {
                 name: profile.displayName,
                 profileImage: profile.profileImage,
@@ -66,7 +71,11 @@ export const findOrCreateOAuthUser = async (provider: OAuthProvider, profile: OA
                 },
             },
         });
+        return { user, isNewUser: true };
     } catch (error) {
-        return recoverConcurrentAccount(provider, profile, error);
+        return {
+            user: await recoverConcurrentAccount(provider, profile, error),
+            isNewUser: false,
+        };
     }
 };

--- a/api/tests/login.test.ts
+++ b/api/tests/login.test.ts
@@ -12,6 +12,7 @@ import { ExternalServiceError } from "@/utils/httpErrors";
 import achievements from "@/handlers/achievements";
 import { getOAuthProvider, type OAuthProviderSlug } from "@/services/oauth";
 import { mergeConfirmationStore } from "@/services/oauth/state";
+import posthog from "@/services/posthog";
 
 let testUser: TestUser;
 const oauthUserIds: string[] = [];
@@ -385,6 +386,15 @@ describe("Login Routes", () => {
         test.each(["google", "discord"] as const)("cria e reutiliza usuário com %s", async (provider) => {
             const providerAccountId = `${provider}-${crypto.randomUUID()}`;
             const restore = mockProvider(provider, providerAccountId);
+            const originalCapture = posthog.capture;
+            const capturedEvents: Array<{
+                distinctId: string;
+                event: string;
+                properties?: Record<string, unknown>;
+            }> = [];
+            posthog.capture = (distinctId, event, properties) => {
+                capturedEvents.push({ distinctId, event, properties });
+            };
             try {
                 const first = await finishProviderCallback(provider);
                 expect(first.status).toBe(302);
@@ -401,6 +411,11 @@ describe("Login Routes", () => {
                 });
                 oauthUserIds.push(account.userId);
                 expect(account.user.name).toBe(`${provider} user`);
+                expect(capturedEvents).toEqual([{
+                    distinctId: account.userId,
+                    event: "user_signed_up",
+                    properties: { oauth_provider: provider },
+                }]);
 
                 const second = await finishProviderCallback(provider);
                 expect(second.status).toBe(302);
@@ -415,7 +430,20 @@ describe("Login Routes", () => {
                     },
                 });
                 expect(users).toBe(1);
+                expect(capturedEvents).toEqual([
+                    {
+                        distinctId: account.userId,
+                        event: "user_signed_up",
+                        properties: { oauth_provider: provider },
+                    },
+                    {
+                        distinctId: account.userId,
+                        event: "user_logged_in",
+                        properties: { oauth_provider: provider },
+                    },
+                ]);
             } finally {
+                posthog.capture = originalCapture;
                 restore();
             }
         });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Track signup and login events in PostHog on OAuth callback
- Updates `findOrCreateOAuthUser` in [accounts.ts](https://github.com/felipe-software/feridinha.com/pull/78/files#diff-61b8c95d45779d4f737071020e5763504e5f7c576251def38281c0831298c0bf) to return `{ user, isNewUser }` instead of a bare user object.
- The OAuth callback handler in [login.ts](https://github.com/felipe-software/feridinha.com/pull/78/files#diff-713ee22159fef3956727a60fa05e87c1feb5f77104b425d4373b2a740aa3e8fc) now calls `posthog.capture` after session creation, emitting `user_signed_up` for new users or `user_logged_in` for returning users, with `oauth_provider` set to the provider slug.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2181120.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->